### PR TITLE
Add admin page for uploading standard army card PDFs

### DIFF
--- a/HeroscapeBuilder.Server/Common/Mapping/MappingProfile.cs
+++ b/HeroscapeBuilder.Server/Common/Mapping/MappingProfile.cs
@@ -25,6 +25,7 @@ namespace HeroscapeBuilder.Server.Common.Mapping
                 });
 
             CreateMap<ArmyCardFile, UnitFileEntity>()
+                .ForMember(dest => dest.UnitName, opt => opt.MapFrom(src => src.ArmyCard.Name))
                 .ForMember(dest => dest.Thumb, opt => opt.MapFrom(src => src.InverseParentNavigation.FirstOrDefault(x => x.FilePurpose.Contains("Thumb")).FilePath))
                 .AfterMap((src, dest) =>
                 {

--- a/HeroscapeBuilder.Server/Data/Repositories/FileRepository.cs
+++ b/HeroscapeBuilder.Server/Data/Repositories/FileRepository.cs
@@ -18,6 +18,8 @@ namespace HeroscapeBuilder.Server.Data.Repositories
                 .Include(f => f.ArmyCard)
                 .Include(f => f.InverseParentNavigation)
                 .Where(x => x.FilePurpose == purpose)
+                .OrderBy(x => x.ArmyCard.Name)
+                .ThenBy(x => x.FilePath)
                 .ToListAsync();
         }
 
@@ -29,13 +31,19 @@ namespace HeroscapeBuilder.Server.Data.Repositories
                 .Include(f => f.ParentNavigation);
             if(armyCardIds.Count == 1 && armyCardIds.First() == -1)
             {
-                return await find.Where(x => x.FilePurpose == purpose).ToListAsync();
+                return await find
+                    .Where(x => x.FilePurpose == purpose)
+                    .OrderBy(x => x.ArmyCard.Name)
+                    .ThenBy(x => x.FilePath)
+                    .ToListAsync();
             }
             else
             {
                 return await find
                     .Where(x => x.FilePurpose == purpose)
                     .Where(x => armyCardIds.Contains(x.ArmyCardId))
+                    .OrderBy(x => x.ArmyCard.Name)
+                    .ThenBy(x => x.FilePath)
                     .ToListAsync();
             }
 

--- a/HeroscapeBuilder.Server/Data/Repositories/FileRepository.cs
+++ b/HeroscapeBuilder.Server/Data/Repositories/FileRepository.cs
@@ -14,12 +14,19 @@ namespace HeroscapeBuilder.Server.Data.Repositories
 
         public async Task<IEnumerable<ArmyCardFile>> GetFiles(string purpose)
         {
-            return await _context.ArmyCardFiles.Include(f => f.InverseParentNavigation).Where(x => x.FilePurpose == purpose).ToListAsync();
+            return await _context.ArmyCardFiles
+                .Include(f => f.ArmyCard)
+                .Include(f => f.InverseParentNavigation)
+                .Where(x => x.FilePurpose == purpose)
+                .ToListAsync();
         }
 
         public async Task<IEnumerable<ArmyCardFile>> GetFiles(List<int> armyCardIds, string purpose)
         {
-            var find = _context.ArmyCardFiles.Include(f => f.InverseParentNavigation).Include(f => f.ParentNavigation);
+            var find = _context.ArmyCardFiles
+                .Include(f => f.ArmyCard)
+                .Include(f => f.InverseParentNavigation)
+                .Include(f => f.ParentNavigation);
             if(armyCardIds.Count == 1 && armyCardIds.First() == -1)
             {
                 return await find.Where(x => x.FilePurpose == purpose).ToListAsync();

--- a/HeroscapeBuilder.Server/Data/Repositories/FileRepository.cs
+++ b/HeroscapeBuilder.Server/Data/Repositories/FileRepository.cs
@@ -31,7 +31,13 @@ namespace HeroscapeBuilder.Server.Data.Repositories
                     .Where(x => armyCardIds.Contains(x.ArmyCardId))
                     .ToListAsync();
             }
-                
+
+        }
+
+        public async Task<ArmyCardFile?> GetArmyCardFileAsync(int armyCardId, string filePurpose)
+        {
+            return await _context.ArmyCardFiles
+                .FirstOrDefaultAsync(x => x.ArmyCardId == armyCardId && x.FilePurpose == filePurpose);
         }
 
         /// <summary>
@@ -74,11 +80,6 @@ namespace HeroscapeBuilder.Server.Data.Repositories
             // Save changes
             await _context.SaveChangesAsync();
             return acfs;
-        }
-
-        public bool FileRecordExists(ArmyCardFile acf)
-        {
-            return _context.ArmyCardFiles.Any(x => x.ArmyCardId == acf.ArmyCardId && x.FilePurpose == acf.FilePurpose && x.FilePath == acf.FilePath);
         }
     }
 }

--- a/HeroscapeBuilder.Server/Domain/Entities/UnitFileEntity.cs
+++ b/HeroscapeBuilder.Server/Domain/Entities/UnitFileEntity.cs
@@ -8,6 +8,8 @@ namespace HeroscapeBuilder.Server.Domain.Entities
 
         public int ArmyCardId { get; set; }
 
+        public string? UnitName { get; set; }
+
         public string FilePurpose { get; set; } = null!;
 
         public string RawFilePath { get; set; }

--- a/HeroscapeBuilder.Server/Services/FileService.cs
+++ b/HeroscapeBuilder.Server/Services/FileService.cs
@@ -25,7 +25,9 @@ namespace HeroscapeBuilder.Server.Services
 
         public async Task<List<UnitFileEntity>> GetFilesByPurpose(string purpose)
         {
-            var files = (await _fileRepository.GetFiles(purpose)).ToList()?.OrderBy(x => x.FilePath).ToList();            
+            var files = (await _fileRepository.GetFiles(purpose))
+                .OrderBy(x => x.UnitName ?? Path.GetFileName(x.FilePath), StringComparer.OrdinalIgnoreCase)
+                .ToList();
 
             if (files == null)
                 throw new ArgumentException("No files found");

--- a/HeroscapeBuilder.Server/Services/FileService.cs
+++ b/HeroscapeBuilder.Server/Services/FileService.cs
@@ -69,35 +69,44 @@ namespace HeroscapeBuilder.Server.Services
             }
 
             var filePath = Path.Combine(fullPath, fileName);
-            var acf = new ArmyCardFile
+            var existingFile = await _fileRepository.GetArmyCardFileAsync(armyCardId, filePurpose);
+
+            if (existingFile != null && existingFile.FilePath != filePath)
             {
-                ArmyCardId = armyCardId,
-                FilePurpose = filePurpose,
-                Parent = parentFileId,
-                FilePath = filePath
-            };
+                await _blobStorage.DeleteAsync(existingFile.FilePath);
+            }
 
-            if (!(await _blobStorage.FileExistsAsync(filePath))) 
+            var uploadResult = await _blobStorage.UploadAsync(fileData, filePath);
+            if (string.IsNullOrEmpty(uploadResult))
             {
+                throw new Exception("Unable to upload file.");
+            }
 
-                //Upload the file to file storage
-                var r = await _blobStorage.UploadAsync(fileData, filePath);
-                if (string.IsNullOrEmpty(r))
+            long fileId;
+            if (existingFile != null)
+            {
+                existingFile.FilePath = filePath;
+                existingFile.Parent = parentFileId;
+                await _fileRepository.UpdateArmyCardFileAsync(existingFile);
+                fileId = existingFile.Id;
+            }
+            else
+            {
+                var acf = new ArmyCardFile
                 {
-                    throw new Exception("Unable to upload file.");
-                }
+                    ArmyCardId = armyCardId,
+                    FilePurpose = filePurpose,
+                    Parent = parentFileId,
+                    FilePath = filePath
+                };
 
-                if (!_fileRepository.FileRecordExists(acf))
-                {
-                    //Save it in the DB
-                    var id = await _fileRepository.AddArmyCardFileAsync(acf);
+                fileId = await _fileRepository.AddArmyCardFileAsync(acf);
+            }
 
-                    if (thumbImage != null)
-                    {
-                        string fileNameWithoutExtension = Path.GetFileNameWithoutExtension(fileName);
-                        await AddFileToUnit(armyCardId, $"{filePurpose}_Thumb", $"pdf-thumbnail-{fileNameWithoutExtension}.png", thumbImage, id);
-                    }
-                }
+            if (thumbImage != null)
+            {
+                string fileNameWithoutExtension = Path.GetFileNameWithoutExtension(fileName);
+                await AddFileToUnit(armyCardId, $"{filePurpose}_Thumb", $"pdf-thumbnail-{fileNameWithoutExtension}.png", thumbImage, fileId);
             }
 
             return true;

--- a/heroscapebuilder.client/src/components/Auth/AdminRoute.tsx
+++ b/heroscapebuilder.client/src/components/Auth/AdminRoute.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { Navigate } from "react-router-dom";
+import { hasRole, isAuthenticated } from "../../services/authService";
+
+interface AdminRouteProps {
+    children: React.ReactElement;
+}
+
+const AdminRoute: React.FC<AdminRouteProps> = ({ children }) => {
+    if (!isAuthenticated()) {
+        return <Navigate to="/user/login" replace />;
+    }
+
+    return hasRole("Admin") ? children : <Navigate to="/" replace />;
+};
+
+export default AdminRoute;

--- a/heroscapebuilder.client/src/components/CardGallery/card-gallery.scss
+++ b/heroscapebuilder.client/src/components/CardGallery/card-gallery.scss
@@ -13,6 +13,9 @@
         transition: transform 0.3s ease, box-shadow 0.3s ease; /* Smooth hover effects */
         /*width: calc(25% - 20px);*/ /* Adjusts width based on gap */
         box-sizing: border-box; /* Ensures padding is included in the width */
+        display: flex;
+        flex-direction: column;
+        align-items: center;
 
         img {
             border-radius: 4px;
@@ -28,6 +31,7 @@
         .checkbox-wrapper {
             margin-top: 10px;
             text-align: left; /* Aligns checkbox and label to the left */
+            width: 100%;
 
             .label-make-pdf {
                 padding-left: 8px;
@@ -36,9 +40,53 @@
             }
         }
 
+        .thumbnail-image-link {
+            width: 100%;
+            display: block;
+        }
+
+        .unit-name {
+            margin-top: 0.5rem;
+            text-align: center;
+            font-size: 0.9rem;
+            font-weight: 600;
+            color: #333;
+            line-height: 1.2;
+            word-break: break-word;
+            width: 100%;
+        }
+
         &:hover {
             transform: translateY(-5px); /* Lift effect on hover */
             box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2); /* Enhanced shadow on hover */
+        }
+    }
+}
+
+@media (max-width: 768px) {
+    .pdf-gallery {
+        gap: 16px;
+
+        .thumbnail {
+            padding: 8px;
+
+            .unit-name {
+                font-size: 0.85rem;
+            }
+        }
+    }
+}
+
+@media (max-width: 576px) {
+    .pdf-gallery {
+        gap: 12px;
+
+        .thumbnail {
+            padding: 6px;
+
+            .unit-name {
+                font-size: 0.8rem;
+            }
         }
     }
 }

--- a/heroscapebuilder.client/src/components/CardGallery/card-gallery.tsx
+++ b/heroscapebuilder.client/src/components/CardGallery/card-gallery.tsx
@@ -25,7 +25,12 @@ const CardGallery: React.FC<CardGalleryProps> = ({ cardSize }) => {
                     setGallerySize("thumbnail col-xxl-2 col-lg-3 col-lg-4");
                 }
 
-                const data = (await getFilesByPurpose(`${cardSize}_Army_Card`)).sort((a, b) => a.filePath.localeCompare(b.filePath));
+                const data = (await getFilesByPurpose(`${cardSize}_Army_Card`)).sort((a, b) => {
+                    const leftName = a.unitName ?? a.fileName ?? a.filePath;
+                    const rightName = b.unitName ?? b.fileName ?? b.filePath;
+
+                    return leftName.localeCompare(rightName, undefined, { sensitivity: "base" });
+                });
                 setFiles(data);
                 setLoading(false);
             } catch (err) {

--- a/heroscapebuilder.client/src/components/CardGallery/card-gallery.tsx
+++ b/heroscapebuilder.client/src/components/CardGallery/card-gallery.tsx
@@ -276,6 +276,10 @@ const CardGallery: React.FC<CardGalleryProps> = ({ cardSize }) => {
         });
     };
 
+    const getDisplayName = (card: UnitFile) => {
+        return card.unitName?.trim() || card.fileName || card.filePath.split('/').pop() || 'PDF Thumbnail';
+    };
+
     return (
         <div className="card-gallery">
             <div className="row">
@@ -293,31 +297,35 @@ const CardGallery: React.FC<CardGalleryProps> = ({ cardSize }) => {
                 </div>
             </div>
             <div className="row pdf-gallery">
-                {files.map((card, index) => (
-                    <div key={card.id || index} className={gallerySize} >
-                        <div className="checkbox-wrapper">
-                            <input
-                                type="checkbox"
-                                className="make-pdf"
-                                onChange={() => handleCheckboxChange(card.filePath)}
-                            />
-                            <label className="label-make-pdf">Add to PDF</label>
+                {files.map((card, index) => {
+                    const displayName = getDisplayName(card);
+                    return (
+                        <div key={card.id || index} className={gallerySize}>
+                            <div className="checkbox-wrapper">
+                                <input
+                                    type="checkbox"
+                                    className="make-pdf"
+                                    onChange={() => handleCheckboxChange(card.filePath)}
+                                />
+                                <label className="label-make-pdf">Add to PDF</label>
+                            </div>
+                            <a className="thumbnail-image-link" href={card.filePath} target="_blank" rel="noopener noreferrer">
+                                <ImageCache
+                                    className="img-fluid"
+                                    src={card.thumb}
+                                    alt={`${displayName} PDF Thumbnail`}
+                                    cacheKey={card.thumb}
+                                />
+                                {/*<img*/}
+                                {/*    className="img-fluid"*/}
+                                {/*    src={card.thumb}*/}
+                                {/*    alt="PDF Thumbnail"*/}
+                                {/*/>*/}
+                            </a>
+                            <div className="unit-name" title={displayName}>{displayName}</div>
                         </div>
-                        <a href={card.filePath} target="_blank">
-                            <ImageCache
-                                className="img-fluid"
-                                src={card.thumb}
-                                alt="PDF Thumbnail"
-                                cacheKey={card.thumb}
-                            />
-                            {/*<img*/}
-                            {/*    className="img-fluid"*/}
-                            {/*    src={card.thumb}*/}
-                            {/*    alt="PDF Thumbnail"*/}
-                            {/*/>*/}
-                        </a>
-                    </div>
-                ))}
+                    );
+                })}
             </div>
         </div>
     );

--- a/heroscapebuilder.client/src/components/Sidebar/Sidebar.tsx
+++ b/heroscapebuilder.client/src/components/Sidebar/Sidebar.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
-import { getUser, isAuthenticated } from "../../services/authService";
+import { getUser, hasRole, isAuthenticated } from "../../services/authService";
 
 const Sidebar: React.FC = () => {
     const [isOpen, setIsOpen] = useState<boolean>(false); // Tracks if sidebar is open
@@ -94,6 +94,9 @@ const Sidebar: React.FC = () => {
                                         <li><Link to="/army-cards/threebyfive" onClick={toggleSidebar}>3x5 Index Cards</Link></li>
                                         <li><Link to="/army-cards/fourbysix" onClick={toggleSidebar}>4x6 Index Cards</Link></li>
                                         <li><Link to="/army-cards/printing" onClick={toggleSidebar}>Printing Cards</Link></li>
+                                        {hasRole("Admin") && (
+                                            <li><Link to="/army-cards/standard/upload" onClick={toggleSidebar}>Upload Standard Card PDF</Link></li>
+                                        )}
                                     </ul>
                                 )}
                             </li>

--- a/heroscapebuilder.client/src/models/unit-file.ts
+++ b/heroscapebuilder.client/src/models/unit-file.ts
@@ -1,8 +1,9 @@
 export interface UnitFile {
     id: number;
-    fileName: string; 
+    fileName: string;
     filePurpose: string;
     filePath: string;
     thumb: string;
+    unitName?: string | null;
     createdAt: Date;
 }

--- a/heroscapebuilder.client/src/pages/App.tsx
+++ b/heroscapebuilder.client/src/pages/App.tsx
@@ -7,6 +7,7 @@ import Sidebar from "../components/Sidebar/Sidebar";
 import FourbysixArmyCards from "../pages/army-cards/fourbysix/fourbysix_army_card";
 import MakeCardStandard from "../pages/army-cards/standard/make-card-standard";
 import ThreebyfiveArmyCards from "../pages/army-cards/threebyfive/threebyfive-army-cards";
+import UploadStandardCard from "../pages/army-cards/standard/upload-standard-card";
 import Home from "./Home/Home";
 import ArmyCards from "./army-cards/army-cards";
 import DownloadfourBySix from "./army-cards/fourbysix/download-fourbysix";
@@ -19,6 +20,7 @@ import MakeCard3x5 from "./army-cards/threebyfive/make-card-3x5";
 import GamePlayCalc from "./game-play/game-play-calc/game-play-calc";
 import UnitData from "./data/unit-data/unit-data";
 import PrivateRoute from "../components/Auth/PrivateRoute";
+import AdminRoute from "../components/Auth/AdminRoute";
 import Login from "../pages/user/Login";
 import Logout from "../pages/user/Logout";
 import Register from "../pages/user/Register";
@@ -37,6 +39,7 @@ const App: React.FC = () => {
                             <Route path="/army-cards/standard" element={<StandardArmyCards />} />
                             <Route path="/army-cards/standard/download" element={<DownloadStandard />} />
                             <Route path="/army-cards/standard/create" element={<MakeCardStandard />} />
+                            <Route path="/army-cards/standard/upload" element={<AdminRoute><UploadStandardCard /></AdminRoute>} />
                             <Route path="/army-cards/threebyfive" element={<ThreebyfiveArmyCards />} />
                             <Route path="/army-cards/threebyfive/download" element={<DownloadThreeByFive />} />
                             <Route path="/army-cards/threebyfive/create" element={<MakeCard3x5 />} />

--- a/heroscapebuilder.client/src/pages/army-cards/standard/upload-standard-card.tsx
+++ b/heroscapebuilder.client/src/pages/army-cards/standard/upload-standard-card.tsx
@@ -1,0 +1,169 @@
+import React, { useEffect, useRef, useState } from "react";
+import { Unit } from "../../../models/unit";
+import { AddFileToUnit } from "../../../services/file-service";
+import { getUnits } from "../../../services/unit-service";
+
+const UploadStandardCard: React.FC = () => {
+    const [loading, setLoading] = useState<boolean>(true);
+    const [unitData, setUnitData] = useState<Unit[]>([]);
+    const [selectedUnit, setSelectedUnit] = useState<string>("");
+    const [pdfFile, setPdfFile] = useState<File | null>(null);
+    const [error, setError] = useState<string>("");
+    const [status, setStatus] = useState<string>("");
+    const [uploading, setUploading] = useState<boolean>(false);
+    const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+    useEffect(() => {
+        const fetchUnits = async () => {
+            try {
+                const units = await getUnits();
+                setUnitData(units);
+            } catch (err) {
+                setError("Unable to load unit data.");
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchUnits();
+    }, []);
+
+    useEffect(() => {
+        async function initializeTooltips() {
+            const bootstrap = await import("bootstrap");
+            const tooltipTriggerList = Array.from(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
+            tooltipTriggerList.forEach((tooltipTriggerEl: Element) => {
+                new bootstrap.Tooltip(tooltipTriggerEl);
+            });
+        }
+
+        if (!loading) {
+            initializeTooltips();
+        }
+    }, [loading]);
+
+    const sanitizeFileName = (name: string) => {
+        return name.replace(/\s+/g, "_");
+    };
+
+    const handleUpload = async (event: React.FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        setError("");
+        setStatus("");
+
+        if (!selectedUnit) {
+            setError("Please select an army card.");
+            return;
+        }
+
+        if (!pdfFile) {
+            setError("Please select a PDF to upload.");
+            return;
+        }
+
+        setUploading(true);
+
+        try {
+            const success = await AddFileToUnit(pdfFile, selectedUnit, "Standard_Army_Card", sanitizeFileName(pdfFile.name));
+            if (success) {
+                setStatus("PDF uploaded successfully.");
+                setPdfFile(null);
+                if (fileInputRef.current) {
+                    fileInputRef.current.value = "";
+                }
+            }
+        } catch (uploadError) {
+            setError("Failed to upload PDF. Please try again.");
+        } finally {
+            setUploading(false);
+        }
+    };
+
+    if (loading) {
+        return <p>Loading...</p>;
+    }
+
+    return (
+        <div className="container-fluid">
+            <div className="row">
+                <div className="col-12 col-lg-8">
+                    <h2 className="mb-4">Upload Standard Army Card PDF</h2>
+                    <form className="row g-3" onSubmit={handleUpload}>
+                        <div className="col-12">
+                            <label htmlFor="unit" className="form-label">
+                                Load Unit Data
+                                <span
+                                    data-bs-toggle="tooltip"
+                                    data-bs-html="true"
+                                    title="Load up the data for an existing unit."
+                                >
+                                    <span className="q">[?]</span>
+                                </span>
+                            </label>
+                            <select
+                                id="unit"
+                                className="form-select"
+                                value={selectedUnit}
+                                onChange={(e) => setSelectedUnit(e.target.value)}
+                            >
+                                <option value="">Select Unit</option>
+                                {unitData
+                                    .sort((a, b) => a.name.localeCompare(b.name))
+                                    .map((unit) => {
+                                        let label = unit.name;
+                                        label = unit.creator !== "HEROSCAPE" ? `(${unit.creator}) ${label}` : label;
+                                        label = unitData
+                                            .map((u) => u.name)
+                                            .filter((name) => name === unit.name)
+                                            .length > 1
+                                            ? `${label}-${unit.set?.name}`
+                                            : label;
+
+                                        return (
+                                            <option key={unit.id} value={unit.id}>
+                                                {label}
+                                            </option>
+                                        );
+                                    })}
+                            </select>
+                        </div>
+                        <div className="col-12">
+                            <label htmlFor="pdfUpload" className="form-label">
+                                Standard Army Card PDF <span className="text-danger">*</span>
+                            </label>
+                            <input
+                                ref={fileInputRef}
+                                id="pdfUpload"
+                                type="file"
+                                className="form-control"
+                                accept="application/pdf"
+                                onChange={(e) => setPdfFile(e.target.files?.[0] ?? null)}
+                            />
+                        </div>
+                        {error && (
+                            <div className="col-12">
+                                <div className="alert alert-danger" role="alert">
+                                    {error}
+                                </div>
+                            </div>
+                        )}
+                        {status && (
+                            <div className="col-12">
+                                <div className="alert alert-success" role="alert">
+                                    {status}
+                                </div>
+                            </div>
+                        )}
+                        <div className="col-12">
+                            <button className="btn btn-primary" type="submit" disabled={uploading}>
+                                {uploading ? "Uploading..." : "Upload PDF"}
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default UploadStandardCard;

--- a/heroscapebuilder.client/src/services/file-service.ts
+++ b/heroscapebuilder.client/src/services/file-service.ts
@@ -94,28 +94,32 @@ export async function downloadAllAsZip(files: any, zipName: any) {
     saveAs(content, zipName);
 }
 
-export async function AddFileToUnit(file: Blob, armyCardId: string, filePurpose: string, fileName: string) {
-    if (hasRole("Admin")) {
-        const formData = new FormData();
-        formData.append("file", file);
+export async function AddFileToUnit(file: Blob, armyCardId: string, filePurpose: string, fileName: string): Promise<boolean> {
+    if (!hasRole("Admin")) {
+        throw new Error("User does not have permission to upload files.");
+    }
 
-        try {
-            const response = await api.put(`/File/AddFileToUnit`, formData, {
-                headers: {
-                    "Content-Type": "multipart/form-data",
-                    "Authorization": `Bearer ${getToken()}`
-                },
-                params: {
-                    armyCardId,
-                    filePurpose,
-                    fileName
-                }
-            });
+    const formData = new FormData();
+    formData.append("file", file);
 
-            console.log(`Uploaded ${filePurpose} file successfully:`, response.data);
-        } catch (error) {
-            console.error("Error uploading file:", error);
-        }
+    try {
+        const response = await api.put(`/File/AddFileToUnit`, formData, {
+            headers: {
+                "Content-Type": "multipart/form-data",
+                "Authorization": `Bearer ${getToken()}`
+            },
+            params: {
+                armyCardId,
+                filePurpose,
+                fileName
+            }
+        });
+
+        console.log(`Uploaded ${filePurpose} file successfully:`, response.data);
+        return true;
+    } catch (error) {
+        console.error("Error uploading file:", error);
+        throw error;
     }
 }
 


### PR DESCRIPTION
## Summary
- add an admin-only route and page for uploading standard army card PDFs to MinIO via the existing file service
- expose the new upload page from the Army Cards navigation only for admins and add an AdminRoute helper
- update the file upload client service to return success for callers and fail fast when invoked without admin rights

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68febea62f1883258a738854f1e65585