### PR TITLE
Fix army card form input handling

### DIFF
--- a/heroscapebuilder.client/src/components/CardMaker/card-maker.tsx
+++ b/heroscapebuilder.client/src/components/CardMaker/card-maker.tsx
@@ -169,6 +169,12 @@ const CardMaker: React.FC<CardMakerProps> = ({ cardSize }) => {
     const handleAbilityChange = (id: number, key: keyof Ability, value: string) => {
         setAbilities(abilities.map((ability) => ability.id === id ? { ...ability, [key]: value } : ability));
     };
+    const handleNumberChange = (
+        setter: React.Dispatch<React.SetStateAction<number | undefined>>
+    ) => (event: React.ChangeEvent<HTMLInputElement>) => {
+        const value = event.target.value;
+        setter(value === '' ? undefined : Number(value));
+    };
 
     //REGION: Images
     const hitboxImageRef = useRef<HTMLInputElement>(null);
@@ -487,7 +493,7 @@ const CardMaker: React.FC<CardMakerProps> = ({ cardSize }) => {
                             <span className="q">[?]</span>
                         </span>
                     </label>
-                    <input type="text" id="unitName" value={unitName} className="form-control" maxLength={35} />
+                    <input type="text" id="unitName" value={unitName} className="form-control" maxLength={35} onChange={(e) => setUnitName(e.target.value)} />
                     {errors.unitName && <div className="invalid-feedback">{errors.unitName}</div>}
                 </div>
 
@@ -502,7 +508,7 @@ const CardMaker: React.FC<CardMakerProps> = ({ cardSize }) => {
                             <span className="q">[?]</span>
                         </span>
                     </label>
-                    <input type="text" id="unitRace" value={unitRace} className="form-control" maxLength={12} />
+                    <input type="text" id="unitRace" value={unitRace} className="form-control" maxLength={12} onChange={(e) => setUnitRace(e.target.value)} />
                     {errors.unitRace && <div className="invalid-feedback">{errors.unitRace}</div>}
                 </div>
 
@@ -517,7 +523,7 @@ const CardMaker: React.FC<CardMakerProps> = ({ cardSize }) => {
                             <span className="q">[?]</span>
                         </span>
                     </label>
-                    <input type="text" id="unitRole" value={unitRole} className="form-control" maxLength={12} />
+                    <input type="text" id="unitRole" value={unitRole} className="form-control" maxLength={12} onChange={(e) => setUnitRole(e.target.value)} />
                     {errors.unitRole && <div className="invalid-feedback">{errors.unitRole}</div>}
                 </div>
 
@@ -532,7 +538,7 @@ const CardMaker: React.FC<CardMakerProps> = ({ cardSize }) => {
                             <span className="q">[?]</span>
                         </span>
                     </label>
-                    <input type="text" id="unitPersonality" value={unitPersonality} className="form-control" maxLength={12} />
+                    <input type="text" id="unitPersonality" value={unitPersonality} className="form-control" maxLength={12} onChange={(e) => setUnitPersonality(e.target.value)} />
                     {errors.unitPersonality && <div className="invalid-feedback">{errors.unitPersonality}</div>}
                 </div>
 
@@ -547,7 +553,7 @@ const CardMaker: React.FC<CardMakerProps> = ({ cardSize }) => {
                             <span className="q">[?]</span>
                         </span>
                     </label>
-                    <input type="text" id="unitPlanet" value={unitPlanet} className="form-control" maxLength={12} />
+                    <input type="text" id="unitPlanet" value={unitPlanet} className="form-control" maxLength={12} onChange={(e) => setUnitPlanet(e.target.value)} />
                     {errors.unitPlanet && <div className="invalid-feedback">{errors.unitPlanet}</div>}
                 </div>
 
@@ -619,7 +625,7 @@ const CardMaker: React.FC<CardMakerProps> = ({ cardSize }) => {
                             <span className="q">[?]</span>
                         </span>
                     </label>
-                    <input type="number" id="unitSize" value={unitSize} className="form-control" />
+                    <input type="number" id="unitSize" value={unitSize} className="form-control" onChange={handleNumberChange(setUnitSize)} />
                     {errors.unitSize && <div className="invalid-feedback">{errors.unitSize}</div>}
                 </div>
 
@@ -704,7 +710,7 @@ const CardMaker: React.FC<CardMakerProps> = ({ cardSize }) => {
                             <span className="q">[?]</span>
                         </span>
                     </label>
-                    <input type="number" id="life" value={life} className="form-control" />
+                    <input type="number" id="life" value={life} className="form-control" onChange={handleNumberChange(setLife)} />
                     {errors.life && <div className="invalid-feedback">{errors.life}</div>}
                 </div>
 
@@ -719,7 +725,7 @@ const CardMaker: React.FC<CardMakerProps> = ({ cardSize }) => {
                             <span className="q">[?]</span>
                         </span>
                     </label>
-                    <input type="number" id="advancedMove" value={advancedMove} className="form-control" />
+                    <input type="number" id="advancedMove" value={advancedMove} className="form-control" onChange={handleNumberChange(setAdvancedMove)} />
                     {errors.advancedMove && <div className="invalid-feedback">{errors.advancedMove}</div>}
                 </div>
 
@@ -734,7 +740,7 @@ const CardMaker: React.FC<CardMakerProps> = ({ cardSize }) => {
                             <span className="q">[?]</span>
                         </span>
                     </label>
-                    <input type="number" id="advancedRange" value={advancedRange} className="form-control" />
+                    <input type="number" id="advancedRange" value={advancedRange} className="form-control" onChange={handleNumberChange(setAdvancedRange)} />
                     {errors.advancedRange && <div className="invalid-feedback">{errors.advancedRange}</div>}
                 </div>
 
@@ -749,7 +755,7 @@ const CardMaker: React.FC<CardMakerProps> = ({ cardSize }) => {
                             <span className="q">[?]</span>
                         </span>
                     </label>
-                    <input type="number" id="advancedAttack" value={advancedAttack} className="form-control" />
+                    <input type="number" id="advancedAttack" value={advancedAttack} className="form-control" onChange={handleNumberChange(setAdvancedAttack)} />
                     {errors.advancedAttack && <div className="invalid-feedback">{errors.advancedAttack}</div>}
                 </div>
 
@@ -764,7 +770,7 @@ const CardMaker: React.FC<CardMakerProps> = ({ cardSize }) => {
                             <span className="q">[?]</span>
                         </span>
                     </label>
-                    <input type="number" id="advancedDefense" value={advancedDefense} className="form-control" />
+                    <input type="number" id="advancedDefense" value={advancedDefense} className="form-control" onChange={handleNumberChange(setAdvancedDefense)} />
                     {errors.advancedDefense && <div className="invalid-feedback">{errors.advancedDefense}</div>}
                 </div>
 
@@ -779,7 +785,7 @@ const CardMaker: React.FC<CardMakerProps> = ({ cardSize }) => {
                             <span className="q">[?]</span>
                         </span>
                     </label>
-                    <input type="number" id="points" value={points} className="form-control" />
+                    <input type="number" id="points" value={points} className="form-control" onChange={handleNumberChange(setPoints)} />
                     {errors.points && <div className="invalid-feedback">{errors.points}</div>}
                 </div>
 
@@ -794,7 +800,7 @@ const CardMaker: React.FC<CardMakerProps> = ({ cardSize }) => {
                             <span className="q">[?]</span>
                         </span>
                     </label>
-                    <input type="number" id="basicMove" value={basicMove} className="form-control" />
+                    <input type="number" id="basicMove" value={basicMove} className="form-control" onChange={handleNumberChange(setBasicMove)} />
                     {errors.basicMove && <div className="invalid-feedback">{errors.basicMove}</div>}
                 </div>
 
@@ -809,7 +815,7 @@ const CardMaker: React.FC<CardMakerProps> = ({ cardSize }) => {
                             <span className="q">[?]</span>
                         </span>
                     </label>
-                    <input type="number" id="basicRange" value={basicRange} className="form-control" />
+                    <input type="number" id="basicRange" value={basicRange} className="form-control" onChange={handleNumberChange(setBasicRange)} />
                     {errors.basicRange && <div className="invalid-feedback">{errors.basicRange}</div>}
                 </div>
 
@@ -824,7 +830,7 @@ const CardMaker: React.FC<CardMakerProps> = ({ cardSize }) => {
                             <span className="q">[?]</span>
                         </span>
                     </label>
-                    <input type="number" id="basicAttack" value={basicAttack} className="form-control" />
+                    <input type="number" id="basicAttack" value={basicAttack} className="form-control" onChange={handleNumberChange(setBasicAttack)} />
                     {errors.basicAttack && <div className="invalid-feedback">{errors.basicAttack}</div>}
                 </div>
 
@@ -839,7 +845,7 @@ const CardMaker: React.FC<CardMakerProps> = ({ cardSize }) => {
                             <span className="q">[?]</span>
                         </span>
                     </label>
-                    <input type="number" id="basicDefense" value={basicDefense} className="form-control" />
+                    <input type="number" id="basicDefense" value={basicDefense} className="form-control" onChange={handleNumberChange(setBasicDefense)} />
                     {errors.basicDefense && <div className="invalid-feedback">{errors.basicDefense}</div>}
                 </div>
 
@@ -901,7 +907,7 @@ const CardMaker: React.FC<CardMakerProps> = ({ cardSize }) => {
                             <span className="q">[?]</span>
                         </span>
                     </label>
-                    <input type="text" id="set" value={setName} className="form-control" />
+                    <input type="text" id="set" value={setName} className="form-control" onChange={(e) => setSetName(e.target.value)} />
                 </div>
 
                 <div className="col-md-6">
@@ -915,7 +921,7 @@ const CardMaker: React.FC<CardMakerProps> = ({ cardSize }) => {
                             <span className="q">[?]</span>
                         </span>
                     </label>
-                    <input type="text" id="unitNumbers" value={unitNumbers} className="form-control" />
+                    <input type="text" id="unitNumbers" value={unitNumbers} className="form-control" onChange={(e) => setUnitNumbers(e.target.value)} />
                 </div>
 
                 <div className="col-md-6">
@@ -929,7 +935,7 @@ const CardMaker: React.FC<CardMakerProps> = ({ cardSize }) => {
                             <span className="q">[?]</span>
                         </span>
                     </label>
-                    <input type="number" id="numberOfUnitsInSet" value={numberOfUnitsInSet} className="form-control" />
+                    <input type="number" id="numberOfUnitsInSet" value={numberOfUnitsInSet} className="form-control" onChange={handleNumberChange(setNumberOfUnitsInSet)} />
                 </div>
 
                 {/*Submit Button*/}

--- a/heroscapebuilder.client/src/components/CardMaker/card-maker.tsx
+++ b/heroscapebuilder.client/src/components/CardMaker/card-maker.tsx
@@ -213,8 +213,7 @@ const CardMaker: React.FC<CardMakerProps> = ({ cardSize }) => {
         e.preventDefault();
 
         const newErrors: Record<string, string> = {};
-        const normalizedCreator = creator.trim() || 'Custom';
-
+        if (!creator.trim()) newErrors.creator = 'Creator is required';
         if (!general.trim()) newErrors.general = 'General is required';
         if (!unitName.trim()) newErrors.unitName = 'Unit name is required';
         if (!unitRace.trim()) newErrors.unitRace = 'Unit race is required';
@@ -246,7 +245,7 @@ const CardMaker: React.FC<CardMakerProps> = ({ cardSize }) => {
             try {
                 setSubmitting(true); // Show spinner while submitting
                 const formData: UnitFormData = {
-                    creator: normalizedCreator, // Maps directly to creator
+                    creator, // Maps directly to creator
                     general, // Optional, so mapped directly to general
                     name: unitName, // unitName maps to name
                     race: unitRace, // unitRace maps to race
@@ -271,7 +270,7 @@ const CardMaker: React.FC<CardMakerProps> = ({ cardSize }) => {
                     abilities, // Maps directly to abilities (Ability[])
                     set: { // setName and numberOfUnitsInSet map to the Set model
                         id: 0, // Set ID can be fetched or assigned later
-                        creator: normalizedCreator, // Maps to the creator of the set
+                        creator: creator, // Maps to the creator of the set
                         name: setName, // Maps to the setName
                         unitsInSet: numberOfUnitsInSet, // Maps to numberOfUnitsInSet
                         createdAt: new Date()
@@ -446,7 +445,8 @@ const CardMaker: React.FC<CardMakerProps> = ({ cardSize }) => {
                         </span>
                     </label>
                     <select id="creator" value={creator} className="form-select" onChange={(e) => setCreator(e.target.value)}>
-                        <option value="">Custom</option>
+                        <option value="">Select Card Creator</option>
+                        <option value="Custom">Custom</option>
                         <option value="HEROSCAPE">Heroscape - Hasbro / Wizards of the Coast</option>
                         <option value="RENEGADE">Heroscape - Renegade</option>
                         <option value="C3V">C3V - Classic Custom Creators of Valhalla</option>
@@ -469,6 +469,7 @@ const CardMaker: React.FC<CardMakerProps> = ({ cardSize }) => {
                         </span>
                     </label>
                     <select id="unitGeneral" value={general} className="form-select" onChange={(e) => setGeneral(e.target.value)}>
+                        <option value="">Select General</option>
                         <option value="Aquilla">Aquilla</option>
                         <option value="Einar">Einar</option>
                         <option value="Jandar">Jandar</option>
@@ -569,6 +570,7 @@ const CardMaker: React.FC<CardMakerProps> = ({ cardSize }) => {
                         </span>
                     </label>
                     <select id="unitRarity" value={unitRarity} className="form-select" onChange={(e) => setUnitRarity(e.target.value)}>
+                        <option value="">Select Unit Rarity</option>
                         <option value="Unique">Unique</option>
                         <option value="Uncommon">Uncommon</option>
                         <option value="Common">Common</option>
@@ -588,6 +590,7 @@ const CardMaker: React.FC<CardMakerProps> = ({ cardSize }) => {
                         </span>
                     </label>
                     <select id="unitType" value={unitType} className="form-select" onChange={(e) => setUnitType(e.target.value)}>
+                        <option value="">Select Unit Type</option>
                         <option value="Hero">Hero</option>
                         <option value="Squad">Squad</option>
                     </select>
@@ -606,6 +609,7 @@ const CardMaker: React.FC<CardMakerProps> = ({ cardSize }) => {
                         </span>
                     </label>
                     <select id="unitSizeCategory" value={unitSizeCategory} className="form-select" onChange={(e) => setUnitSizeCategory(e.target.value)}>
+                        <option value="">Select Size Category</option>
                         <option value="Huge">Huge</option>
                         <option value="Large">Large</option>
                         <option value="Medium">Medium</option>

--- a/heroscapebuilder.client/src/components/CardMaker/card-maker.tsx
+++ b/heroscapebuilder.client/src/components/CardMaker/card-maker.tsx
@@ -213,8 +213,8 @@ const CardMaker: React.FC<CardMakerProps> = ({ cardSize }) => {
         e.preventDefault();
 
         const newErrors: Record<string, string> = {};
+        const normalizedCreator = creator.trim() || 'Custom';
 
-        if (!creator.trim()) newErrors.creator = 'Creator is required';
         if (!general.trim()) newErrors.general = 'General is required';
         if (!unitName.trim()) newErrors.unitName = 'Unit name is required';
         if (!unitRace.trim()) newErrors.unitRace = 'Unit race is required';
@@ -246,7 +246,7 @@ const CardMaker: React.FC<CardMakerProps> = ({ cardSize }) => {
             try {
                 setSubmitting(true); // Show spinner while submitting
                 const formData: UnitFormData = {
-                    creator, // Maps directly to creator
+                    creator: normalizedCreator, // Maps directly to creator
                     general, // Optional, so mapped directly to general
                     name: unitName, // unitName maps to name
                     race: unitRace, // unitRace maps to race
@@ -271,7 +271,7 @@ const CardMaker: React.FC<CardMakerProps> = ({ cardSize }) => {
                     abilities, // Maps directly to abilities (Ability[])
                     set: { // setName and numberOfUnitsInSet map to the Set model
                         id: 0, // Set ID can be fetched or assigned later
-                        creator: creator, // Maps to the creator of the set
+                        creator: normalizedCreator, // Maps to the creator of the set
                         name: setName, // Maps to the setName
                         unitsInSet: numberOfUnitsInSet, // Maps to numberOfUnitsInSet
                         createdAt: new Date()


### PR DESCRIPTION
### Motivation

- The 3x5 army card creator form had controlled inputs without change handlers, preventing typing into text and numeric fields.
- Numeric fields also needed a way to clear values (empty string) while keeping state typed as `number | undefined`.
- Restore expected editable behavior for users creating/editing army cards.

### Description

- Updated `heroscapebuilder.client/src/components/CardMaker/card-maker.tsx` to add missing input handlers.
- Added a shared number handler `handleNumberChange` to parse and set `number | undefined` state from `<input type="number">` values.
- Wired `onChange` for text fields (e.g. `unitName`, `unitRace`, `unitRole`, `unitPersonality`, `unitPlanet`, `setName`, `unitNumbers`) to their `set*` state setters.
- Wired `onChange={handleNumberChange(...)}` for numeric fields (e.g. `unitSize`, `life`, `advancedMove`, `advancedRange`, `advancedAttack`, `advancedDefense`, `points`, `basicMove`, `basicRange`, `basicAttack`, `basicDefense`, `numberOfUnitsInSet`).

### Testing

- Automated tests: none were run.
- Local build/commit: file modified and committed (`card-maker.tsx`).
- Manual verification should confirm text and numeric inputs are now editable and numeric fields can be cleared.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69457c494c2c83259c5337ffe0bfd82b)