### PR TITLE
Fix TS7006 implicit `any` errors in client (services + CardGallery)

### DIFF
--- a/heroscapebuilder.client/src/components/CardGallery/card-gallery.tsx
+++ b/heroscapebuilder.client/src/components/CardGallery/card-gallery.tsx
@@ -25,7 +25,7 @@ const CardGallery: React.FC<CardGalleryProps> = ({ cardSize }) => {
                     setGallerySize("thumbnail col-xxl-2 col-lg-3 col-lg-4");
                 }
 
-                const data = (await getFilesByPurpose(`${cardSize}_Army_Card`)).sort((a, b) => {
+                const data = (await getFilesByPurpose(`${cardSize}_Army_Card`)).sort((a: UnitFile, b: UnitFile) => {
                     const leftName = a.unitName ?? a.fileName ?? a.filePath;
                     const rightName = b.unitName ?? b.fileName ?? b.filePath;
 

--- a/heroscapebuilder.client/src/services/file-service.ts
+++ b/heroscapebuilder.client/src/services/file-service.ts
@@ -4,12 +4,13 @@ import { blobCache } from './cache-manager';
 import { debounce } from './debounce';
 import { getToken, hasRole } from './authService';
 import AxiosSingletonService from './AxiosSingletonService';
+import { UnitFile } from '../models/unit-file';
 
 const api = AxiosSingletonService.getInstance();
 
-export const getFilesByPurpose = debounce(async (purpose:string) => {
+export const getFilesByPurpose = debounce(async (purpose: string): Promise<UnitFile[]> => {
     try {
-        return (await api.get(`/File/GetFilesByPurpose?purpose=${purpose}`)).data
+        return (await api.get<UnitFile[]>(`/File/GetFilesByPurpose?purpose=${purpose}`)).data;
     } catch (error) {
         console.error('Error fetching files:', error);
         throw error;

--- a/heroscapebuilder.client/src/services/unit-service.ts
+++ b/heroscapebuilder.client/src/services/unit-service.ts
@@ -1,11 +1,13 @@
 import AxiosSingletonService from './AxiosSingletonService';
 import { debounce } from './debounce';
+import { Unit } from '../models/unit';
+import { UnitFile } from '../models/unit-file';
 
 const api = AxiosSingletonService.getInstance();
 
-export const getUnits = debounce(async () => {
+export const getUnits = debounce(async (): Promise<Unit[]> => {
     try {
-        return (await api.get(`/Unit/GetAllUnits`)).data
+        return (await api.get<Unit[]>(`/Unit/GetAllUnits`)).data;
     } catch (error) {
         console.error('Error fetching cards:', error);
         throw error;
@@ -15,7 +17,9 @@ export const getUnits = debounce(async () => {
 export const getUnitsByCardType = debounce(async (cardSize: string) => {
     try {
         const response = await getUnits();
-        return response.map(x => x.files.filter(y => y.filePurpose == `${cardSize}_Army_Card`))
+        return response.map((unit: Unit) =>
+            unit.files.filter((file: UnitFile) => file.filePurpose == `${cardSize}_Army_Card`),
+        );
 
     } catch (error) {
         console.error('Error fetching cards:', error);


### PR DESCRIPTION
### Motivation
- Address TypeScript `TS7006` errors caused by implicit `any` parameters during the client build.
- Improve type-safety for file/unit related service functions and the CardGallery sorting callback.
- Make responses from API calls explicit so downstream code receives typed values.
- Reduce chance of regressions by matching runtime data with model interfaces (`Unit`, `UnitFile`).

### Description
- Annotated the CardGallery sort callback to use `UnitFile` for parameters: `sort((a: UnitFile, b: UnitFile) => ...)` in `src/components/CardGallery/card-gallery.tsx`.
- Added `UnitFile` import and typed the `getFilesByPurpose` function to return `Promise<UnitFile[]>` and used a typed API call in `src/services/file-service.ts`.
- Added `Unit` and `UnitFile` imports in `src/services/unit-service.ts`, typed `getUnits` to return `Promise<Unit[]>`, and updated `getUnitsByCardType` to use typed parameters/returns when filtering `unit.files`.
- Small related cleanup to ensure consistent typing across the client service boundaries.

### Testing
- No automated tests were executed as part of this change.
- Please run `npm run build` (client) and `dotnet publish` (server) locally/CI to verify that the original `TS7006` errors are resolved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945c1ad730c8325b09e95a8d01d1843)