### PR TITLE
Add Google Analytics (gtag) to client entrypoint

### DIFF
--- a/heroscapebuilder.client/index.html
+++ b/heroscapebuilder.client/index.html
@@ -9,6 +9,14 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/WKnight16.png">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Heroscape Builder</title>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-0901T32E95"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag() { dataLayer.push(arguments); }
+        gtag('js', new Date());
+
+        gtag('config', 'G-0901T32E95');
+    </script>
 </head>
 <body>
     <div id="root"></div>


### PR DESCRIPTION
### Motivation
- Enable Google Analytics tracking for the web app so page views and events can be collected.
- Use the provided Measurement ID `G-0901T32E95` to ensure data flows to the correct property.
- Inject the tracking snippet at the client entrypoint so it runs for all pages served by the app.

### Description
- Added an async `gtag` script tag to `heroscapebuilder.client/index.html` that loads `https://www.googletagmanager.com/gtag/js` with the given measurement ID.
- Initialized `window.dataLayer` and defined the `gtag()` helper function in the HTML head.
- Called `gtag('js', new Date())` and `gtag('config', 'G-0901T32E95')` to configure tracking on page load.
- Change is limited to the static client HTML template (`index.html`).

### Testing
- No automated tests were run for this change.
- No CI/build was executed as part of this update (static HTML modification).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69645cf290788325ae72330f076aaab4)