### PR TITLE
Add STL download links to Unit Data grid

### DIFF
--- a/HeroscapeBuilder.Server/Common/Mapping/MappingProfile.cs
+++ b/HeroscapeBuilder.Server/Common/Mapping/MappingProfile.cs
@@ -13,6 +13,13 @@ namespace HeroscapeBuilder.Server.Common.Mapping
                 .ForMember(dest => dest.Set, opt => opt.MapFrom(src => src.SetNavigation))
                 .ForMember(dest => dest.Abilities, opt => opt.MapFrom(src => src.ArmyCardAbilities.ToList()))
                 .ForMember(dest => dest.Files, opt => opt.MapFrom(src => src.ArmyCardFiles.ToList()))
+                .ForMember(
+                    dest => dest.StlUrls,
+                    opt => opt.MapFrom(
+                        src => src.ArmyCardStls
+                            .OrderBy(stl => stl.StlUrl)
+                            .Select(stl => stl.StlUrl)
+                            .ToList()))
                 .AfterMap((src, dest) =>
                 {
                     TransformCaseHelper.ApplyTransformations(dest);

--- a/HeroscapeBuilder.Server/Data/Repositories/ArmyCardRepository.cs
+++ b/HeroscapeBuilder.Server/Data/Repositories/ArmyCardRepository.cs
@@ -20,6 +20,7 @@ namespace HeroscapeBuilder.Server.Data.Repositories
                 .Include(x => x.SetNavigation)
                 .Include(x => x.ArmyCardAbilities)
                 .Include(x => x.ArmyCardFiles)
+                .Include(x => x.ArmyCardStls)
                 .ToListAsync();
         }
     }

--- a/HeroscapeBuilder.Server/Domain/Entities/UnitEntity.cs
+++ b/HeroscapeBuilder.Server/Domain/Entities/UnitEntity.cs
@@ -66,6 +66,8 @@ namespace HeroscapeBuilder.Server.Domain.Entities
 
         public string? Note { get; set; }
 
+        public List<string> StlUrls { get; set; } = new List<string>();
+
         public List<AbilityEntity> Abilities { get; set; } = new List<AbilityEntity>();
 
         public virtual ICollection<UnitFileEntity> Files { get; set; } = new List<UnitFileEntity>();

--- a/heroscapebuilder.client/src/models/unit.ts
+++ b/heroscapebuilder.client/src/models/unit.ts
@@ -31,4 +31,5 @@ export interface Unit {
     note?: string;
     abilities: Ability[]; // Assuming Ability is another model you'll define
     files: UnitFile[]; // Assuming UnitFile is another model you'll define
+    stlUrls?: string[];
 }

--- a/heroscapebuilder.client/src/pages/data/unit-data/unit-data.scss
+++ b/heroscapebuilder.client/src/pages/data/unit-data/unit-data.scss
@@ -1,10 +1,11 @@
-.unit-data-active{
+.unit-data-active {
     .main-panel {
         > .content {
             padding: 0;
             margin: 0;
             min-height: calc(100vh - 100px);
         }
+
         .unit-data-toolbar {
             display: flex;
             gap: 8px;
@@ -19,10 +20,12 @@
 
             .stl-links-cell {
                 display: flex;
-                flex-direction: column;
-                gap: 4px;
+                flex-direction: row;
+                gap: 6px;
                 padding: 4px 0;
                 line-height: 1.2;
+                white-space: nowrap;
+                width: fit-content;
 
                 a {
                     width: fit-content;

--- a/heroscapebuilder.client/src/pages/data/unit-data/unit-data.scss
+++ b/heroscapebuilder.client/src/pages/data/unit-data/unit-data.scss
@@ -16,6 +16,18 @@
             height: calc(91vh - 70px);
             width: 100%;
             padding: 0 8px 12px;
+
+            .stl-links-cell {
+                display: flex;
+                flex-direction: column;
+                gap: 4px;
+                padding: 4px 0;
+                line-height: 1.2;
+
+                a {
+                    width: fit-content;
+                }
+            }
         }
 
         @media (max-width: 768px) {

--- a/heroscapebuilder.client/src/pages/data/unit-data/unit-data.tsx
+++ b/heroscapebuilder.client/src/pages/data/unit-data/unit-data.tsx
@@ -110,10 +110,10 @@ const UnitData: React.FC = () => {
         },
         {
             field: 'stlUrls',
-            headerName: 'STL Files',
-            minWidth: 220,
+            headerName: '3D Models',
+            minWidth: 260,
             autoHeight: true,
-            wrapText: true,
+            wrapText: false,
             valueGetter: (params: ValueGetterParams<Unit, string>) =>
                 params.data?.stlUrls?.join(' | ') ?? '',
             cellRenderer: (params: ICellRendererParams<Unit>) => {
@@ -127,7 +127,7 @@ const UnitData: React.FC = () => {
                     <div className="stl-links-cell">
                         {stlUrls.map((url, index) => (
                             <a key={`${url}-${index}`} href={url} target="_blank" rel="noopener noreferrer">
-                                STL {index + 1}
+                                &#9830;STL{index + 1}
                             </a>
                         ))}
                     </div>

--- a/heroscapebuilder.client/src/pages/data/unit-data/unit-data.tsx
+++ b/heroscapebuilder.client/src/pages/data/unit-data/unit-data.tsx
@@ -108,6 +108,33 @@ const UnitData: React.FC = () => {
                 </span>
             ),
         },
+        {
+            field: 'stlUrls',
+            headerName: 'STL Files',
+            minWidth: 220,
+            autoHeight: true,
+            wrapText: true,
+            valueGetter: (params: ValueGetterParams<Unit, string>) =>
+                params.data?.stlUrls?.join(' | ') ?? '',
+            cellRenderer: (params: ICellRendererParams<Unit>) => {
+                const stlUrls = params.data?.stlUrls ?? [];
+
+                if (stlUrls.length === 0) {
+                    return <span>-</span>;
+                }
+
+                return (
+                    <div className="stl-links-cell">
+                        {stlUrls.map((url, index) => (
+                            <a key={`${url}-${index}`} href={url} target="_blank" rel="noopener noreferrer">
+                                STL {index + 1}
+                            </a>
+                        ))}
+                    </div>
+                );
+            },
+            cellStyle: { display: 'flex', alignItems: 'center' },
+        },
     ], []);
 
     const defaultColDef = useMemo<ColDef>(() => ({


### PR DESCRIPTION
### Motivation
- Surface `army_card_stl` URLs in the Unit Data UI so users can open/download STL files associated with each army card. 

### Description
- Include `ArmyCardStls` in the repository query by adding `.Include(x => x.ArmyCardStls)` to `GetAllArmyCards()` in `ArmyCardRepository`.  
- Map the STL URLs into the unit DTO by adding `StlUrls` to `UnitEntity` and mapping `ArmyCardStls` → `UnitEntity.StlUrls` in `MappingProfile` (sorted and projected to a `List<string>`).  
- Expose `stlUrls` in the client model by adding `stlUrls?: string[]` to `heroscapebuilder.client/src/models/unit.ts`.  
- Add a new `STL Files` column to the Unit Data grid (`unit-data.tsx`) that renders each URL as a hyperlink (opens in a new tab) and a small cell styling update (`unit-data.scss`) that stacks links vertically.

### Testing
- `npm ci` (in `heroscapebuilder.client`) — succeeded.  
- `npm run build` (in `heroscapebuilder.client`) — succeeded and produced a production build.  
- `npm run lint` (in `heroscapebuilder.client`) — ran but failed due to existing repository-wide lint errors unrelated to these changes.  
- `dotnet test HeroscapeBuilder.sln` — not run because the .NET SDK is not available in the execution environment.  
- A Playwright-based UI mock was used to verify rendering (screenshot produced) while the backend could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974ec832f40832580b769e390a10f9c)